### PR TITLE
Fix unwanted overwrite of segment files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LibraryTargetFrameworks>netstandard2.1;net6.0;net7.0</LibraryTargetFrameworks>
         <TestTargetFrameworks>net6.0;net7.0</TestTargetFrameworks>
-        <VersionPrefix>0.2.1</VersionPrefix>
+        <VersionPrefix>0.2.2</VersionPrefix>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/TeaSuite.KV/IO/FileSegmentManager.SegmentWriter.cs
+++ b/src/TeaSuite.KV/IO/FileSegmentManager.SegmentWriter.cs
@@ -23,13 +23,15 @@ partial class FileSegmentManager<TKey, TValue>
         /// <inheritdoc/>
         public ValueTask<Stream> OpenIndexForWriteAsync(CancellationToken cancellationToken)
         {
-            return new ValueTask<Stream>(File.Open(indexFilePath, FileMode.Create, FileAccess.Write, FileShare.None));
+            return new ValueTask<Stream>(
+                File.Open(indexFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None));
         }
 
         /// <inheritdoc/>
         public ValueTask<Stream> OpenDataForWriteAsync(CancellationToken cancellationToken)
         {
-            return new ValueTask<Stream>(File.Open(dataFilePath, FileMode.Create, FileAccess.Write, FileShare.None));
+            return new ValueTask<Stream>(
+                File.Open(dataFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None));
         }
 
         /// <inheritdoc/>

--- a/test/TeaSuite.KV.UnitTests/IO/FileSegmentManagerTests.cs
+++ b/test/TeaSuite.KV.UnitTests/IO/FileSegmentManagerTests.cs
@@ -153,6 +153,36 @@ public sealed class FileSegmentManagerTests
         Assert.Equal(entryValue, entry.Value.Value);
     }
 
+    [Theory, AutoData]
+    public async Task CreateNewSegmentFailsWhenSegmentExists(long segmentId)
+    {
+        static async Task TryWriteAsync(Driver<int, int> driver)
+        {
+            await driver.WriteEntriesAsync(
+                Enumerable.Empty<StoreEntry<int, int>>().GetEnumerator(),
+                new StoreSettings(),
+                default);
+        }
+
+        Segment<int, int> seg = manager.CreateNewSegment(segmentId);
+        await TryWriteAsync(seg.Driver);
+
+        seg = manager.CreateNewSegment(segmentId);
+        IOException ex = await Assert.ThrowsAsync<IOException>(
+            () => TryWriteAsync(seg.Driver));
+
+        if (Environment.OSVersion.Platform == PlatformID.Unix)
+        {
+            // EEXIST 17 File exists
+            Assert.Equal(17, ex.HResult);
+        }
+        else
+        {
+            // NOTE: Error/HResult checks for other platforms used for testing must be added here.
+            Assert.Fail("Please add proper error check for this platform.");
+        }
+    }
+
     private (string indexFile, string dataFile) GetFileNames(long segmentId)
     {
         string indexFile = Path.Combine(fileSegmentsOptions.SegmentsDirectoryPath, $"segment_{segmentId:d12}.index");


### PR DESCRIPTION
Previously, when a segment file already existed, it would get overwritten - which is a bug.
This change has an exception thrown when a segment file to be written already exists.