### PR TITLE
Update pre-release and release workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,8 +1,8 @@
 name: PreRelease
 
 on:
-  push:
-    branches: ["release/**"]
+  release:
+    types: [prereleased]
 
 env:
   DOTNET_VERSIONS: |
@@ -46,18 +46,18 @@ jobs:
             --results-directory 'TestResults/Temp'
 
       - name: Install report generator
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           dotnet tool install --global dotnet-reportgenerator-globaltool
 
       - name: Generate report
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           reportgenerator -reports:"TestResults/Temp/*/coverage.cobertura.xml" \
             -targetdir:coverage '-reporttypes:Html_Dark;MarkdownSummaryGithub'
 
       - name: Write to Job Summary
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: cat coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
   publish:
@@ -71,12 +71,16 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSIONS }}
 
+      - name: Get version
+        # Extract the version from the pre-release tag.
+        run: |
+          TAG_NAME=$GITHUB_REF_NAME
+          VERSION=$(echo $TAG_NAME | sed -r 's/^v?([0-9.]+-.+)$/\1/')
+          echo "Version=$VERSION" >> $GITHUB_ENV
+
       - name: Create NuGet Package
         run: |
-          SHORT_HASH=$(git rev-parse --short HEAD)
-          dotnet pack TeaSuite.KV.sln --configuration Release -p:VersionSuffix=rc-$SHORT_HASH
-          mkdir packages/ || true
-          cp $(find ./ -name *.nupkg -print) packages/
+          dotnet pack TeaSuite.KV.sln --configuration Release --output packages/
 
       - name: Publish NuGet Package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 env:
   DOTNET_VERSIONS: |
@@ -11,7 +11,57 @@ env:
     8.0.x
 
 jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSIONS }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: |
+          dotnet restore TeaSuite.KV.sln
+          dotnet restore Examples.sln
+
+      - name: Build
+        run: |
+          dotnet build TeaSuite.KV.sln --no-restore --configuration Release
+          dotnet build Examples.sln --no-restore --configuration Release
+
+      - name: Test
+        run: |
+          dotnet test TeaSuite.KV.sln --no-build --configuration Release  \
+            --collect:'XPlat Code Coverage'                               \
+            --results-directory 'TestResults/Temp'
+
+      - name: Install report generator
+        if: ${{ !cancelled() }}
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+
+      - name: Generate report
+        if: ${{ !cancelled() }}
+        run: |
+          reportgenerator -reports:"TestResults/Temp/*/coverage.cobertura.xml" \
+            -targetdir:coverage '-reporttypes:Html_Dark;MarkdownSummaryGithub'
+
+      - name: Write to Job Summary
+        if: ${{ !cancelled() }}
+        run: cat coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+
   publish:
+    needs: build-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,11 +71,16 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSIONS }}
 
+      - name: Get version
+        # Extract the version from the release tag.
+        run: |
+          TAG_NAME=$GITHUB_REF_NAME
+          VERSION=$(echo $TAG_NAME | sed -r 's/^v?([0-9.]+)$/\1/')
+          echo "Version=$VERSION" >> $GITHUB_ENV
+
       - name: Create NuGet Package
         run: |
-          dotnet pack TeaSuite.KV.sln --configuration Release
-          mkdir packages/ || true
-          cp $(find ./ -name *.nupkg -print) packages/
+          dotnet pack TeaSuite.KV.sln --configuration Release --output packages/
 
       - name: Publish NuGet Package
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 coverage/
 TestResults/
+packages/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,6 @@
         <Nullable>enable</Nullable>
         <LibraryTargetFrameworks>net6.0;net7.0;net8.0</LibraryTargetFrameworks>
         <TestTargetFrameworks>net6.0;net7.0;net8.0</TestTargetFrameworks>
-        <VersionPrefix>0.2.2</VersionPrefix>
     </PropertyGroup>
 
     <PropertyGroup Label="SystemDependencyVersions">


### PR DESCRIPTION
- Trigger the pre-release workflow when a pre-release is published.
- Trigger the release workflow when a release is published.
- Use the pre-release/release tag for Nuget package versioning.